### PR TITLE
Revert "feat(docker-image): update quay.io/minio/minio docker tag to release.2023-05-04t21-44-30z"

### DIFF
--- a/infrastructure/ansible/inventory/host_vars/nas/main.yml
+++ b/infrastructure/ansible/inventory/host_vars/nas/main.yml
@@ -21,7 +21,7 @@ apps:
 
   minio:
     # renovate: docker-image
-    image: quay.io/minio/minio:RELEASE.2023-05-04T21-44-30Z
+    image: quay.io/minio/minio:RELEASE.2023-04-28T18-11-17Z
     data_folder: /volume1/docker/minio/data
 
   node_exporter:

--- a/kubernetes/cluster-0/apps/storage/minio/app/helmrelease.yaml
+++ b/kubernetes/cluster-0/apps/storage/minio/app/helmrelease.yaml
@@ -26,7 +26,7 @@ spec:
       nameOverride: *app
     image:
       repository: quay.io/minio/minio
-      tag: RELEASE.2023-05-04T21-44-30Z
+      tag: RELEASE.2023-04-28T18-11-17Z
     controller:
       annotations:
         reloader.stakater.com/auto: "true"


### PR DESCRIPTION
Reverts jahanson/home-ops#266. Increased round trips from 1s-5s for less than a kb.